### PR TITLE
Fix Tweenable.prototype.to( target ).

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -333,10 +333,14 @@
    * @param {String|Object} easing The easing formula to use.
    */
   Tweenable.prototype.to = function to (target, duration, callback, easing) {
-    if (typeof duration === 'undefined') {
-      // Shorthand notation is being used
-      target.from = this.get();
-      this.tween(target);
+    if (arguments.length === 1) {
+      if ('to' in target) {
+        // Shorthand notation is being used
+        target.from = this.get();
+        this.tween(target);
+      } else {
+        this.tween(this.get(), target);
+      }
     } else {
       // Longhand notation is being used
       this.tween(this.get(), target, duration, callback, easing);


### PR DESCRIPTION
It was considering first argument to always be the object containing
all the parameters (shorthand notation) but it isn't always true.
