### PR TITLE
Remove noop callback and step from core, reuse same fn on queue.

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -167,7 +167,9 @@
         invokeHook('step', params.hook, params.owner, [state.current]);
       }
       
-      params.step.call(state.current);
+      if (params.step) {
+        params.step.call(state.current);
+      }
       
     } else {
       // The duration of the tween has expired
@@ -289,16 +291,15 @@
     // Normalize some internal values depending on how `tweenableInst.tween` was invoked
     if (to) {
       // Assume the shorthand syntax is being used.
-      params.step = function () {};
       params.to = to || {};
       params.duration = duration || this.duration;
-      params.callback = callback || function () {};
+      params.callback = callback;
       params.easing = easing || this.easing;
       state.current = from || {};
     } else {
       // If the second argument is not present, assume the longhand syntax is being used.
-      params.step = from.step || function () {};
-      params.callback = from.callback || function () {};
+      params.step = from.step;
+      params.callback = from.callback;
       params.to = from.to || from.target || {};
       params.duration = from.duration || this.duration;
       params.easing = from.easing || this.easing;
@@ -375,7 +376,9 @@
     if (gotoEnd) {
       simpleCopy(this._state.current, this._tweenParams.to);
       applyFilter('afterTweenEnd', this, [this._state.current, this._tweenParams.originalState, this._tweenParams.to]);
-      this._tweenParams.callback.call(this._state.current);
+      if (this._tweenParams.callback) {
+        this._tweenParams.callback.call(this._state.current);
+      }
     }
     
     return this;

--- a/src/shifty.queue.js
+++ b/src/shifty.queue.js
@@ -16,6 +16,8 @@ MIT Lincense.  This code free to use, modify, distribute and enjoy.
 */
 
 (function shiftyQueue (global) {
+
+  var noop = function(){};
   
   function iterateQueue (queue) {
     queue.shift();
@@ -65,7 +67,7 @@ MIT Lincense.  This code free to use, modify, distribute and enjoy.
     }
 
     // Make sure there is always an invokable callback
-    callback = callback || from.callback || function () {};
+    callback = callback || from.callback || noop;
     wrappedCallback = getWrappedCallback(callback, this._tweenQueue);
     this._tweenQueue.push(tweenInit(this, from, to, duration, wrappedCallback, easing));
 


### PR DESCRIPTION
There is no need to create a new noop function for each tween if it
isn't going to be called, added checks so it is only called if
available and on queue it reuses same noop function for all calls
if needed.
