### PR TITLE
Updated .each to use Object's hasOwnProperty

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -48,7 +48,7 @@ if (typeof SHIFTY_DEBUG_NOW === 'undefined') {
     var prop;
 
     for (prop in obj) {
-      if (obj.hasOwnProperty(prop)) {
+      if (Object.hasOwnProperty.call(obj, prop)) {
         func(obj, prop);
       }
     }


### PR DESCRIPTION
If somebody decides to use 'hasOwnProperty' as a dictionary key, we're in trouble. So instead, we use the standard Object's version of the method to avoid the danger.
