### PR TITLE
Fix API documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Shifty](#building-shifty)).
 
 This section explains how to get started with Shifty.  For full documentation
 on each method, please see [the API
-documentation](http://jeremyckahn.github.io/shifty/dist/doc/src/shifty.core.js.html).
+documentation](http://jeremyckahn.github.io/shifty/dist/doc/classes/Tweenable.html).
 
 ## Making a `tweenable()` instance
 
@@ -133,7 +133,7 @@ Tweenable.prototype.set();
 ````
 
 These, as well as all other methods, are detailed more in the [API
-documentation](http://jeremyckahn.github.io/shifty/dist/doc/src/shifty.core.js.html).
+documentation](http://jeremyckahn.github.io/shifty/dist/doc/classes/Tweenable.html).
 
 ## Using multiple easing formulas
 


### PR DESCRIPTION
I guess these have been missed when updating to YUI doc
