### PR TITLE
Protected config variable from mutation by adding clone function

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -184,6 +184,11 @@ var Tweenable = (function () {
     }
   }
 
+  function clone (obj) {
+    if (obj) {
+      return JSON.parse(JSON.stringify(obj));
+    }
+  }
 
   /*!
    * Creates a usable easing Object from either a string or another easing
@@ -300,9 +305,9 @@ var Tweenable = (function () {
     this._step = config.step || noop;
     this._finish = config.finish || noop;
     this._duration = config.duration || DEFAULT_DURATION;
-    this._currentState = config.from || this.get();
+    this._currentState = clone(config.from) || this.get();
     this._originalState = this.get();
-    this._targetState = config.to || this.get();
+    this._targetState = clone(config.to) || this.get();
 
     var self = this;
     this._timeoutHandler = function () {

--- a/tests/index.html
+++ b/tests/index.html
@@ -116,13 +116,16 @@
     test('seek() forces the tween to a specific point on the timeline', function () {
       var tweenable = new Tweenable();
       mockTime = function () {return 0;};
-      tweenable.tween({
+      var config = {
         from: { x: 0 },
         to: { x: 100 },
         duration: 1000
       });
+      tweenable.tween(config);
 
       tweenable.seek(500);
+      equals(config.from.x, 0);
+      equals(config.to.x, 100); 
       equals(tweenable._timestamp, -500, 'The timestamp was properly offset');
     });
 


### PR DESCRIPTION
When creating a Tweenable object and then trying to seek, the config which was initially passed into the Tweenable object's constructor get's mutated by the timeoutHandler function. It was causing my seeks to be inconsistent.

I added a clone function to make sure the config's from and to property doesn't get mutated.

e.g.
var config = {from: {opacity: 0}, to: {opacity:1}, duration 100};
var tween = new Tweenable(duration);
tween.seek(20); //Config get's changed to {from: {opacity: 0.2}, to: {opacity:1}, duration 100};
tween.seek(60); //Config get's changed to {from: {opacity: 0.6}, to: {opacity:1}, duration 100};
