### PR TITLE
Update test to assert rather than throwing - fix #60

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -152,11 +152,13 @@
         return 98;
       };
 
+      var callCount = 0;
       tweenable.stop = function () {
-        throw new Error('stop shouldn\'t be called');
+        callCount += 1;
       };
 
       tweenable.seek(98);
+      equals(callCount, 0, 'stop should not have been called');
     });
 
 


### PR DESCRIPTION
The idea is to check `Tweenable#stop()` is not called when were not seeking near the end of the tween.