### PR TITLE
Interpolate + delay failing test

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -100,7 +100,8 @@ var Tweenable = (function () {
    */
   function tweenProps (forPosition, currentState, originalState, targetState,
     duration, timestamp, easing) {
-    var normalizedPosition = (forPosition - timestamp) / duration;
+      var normalizedPosition = forPosition < timestamp ? 0 : (forPosition - timestamp) / duration;
+
 
     var prop;
     for (prop in currentState) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -281,11 +281,11 @@
       equals(interpolated.x, 0, 'Beginning of delayed tween was computed');
 
       interpolated = Tweenable.interpolate(
-        { x: 0 }, { x: 10 }, .75, 'linear', .5);
+        { x: 0 }, { x: 10 }, 1.0, 'linear', .5);
       equals(interpolated.x, 5, 'Midpoint delayed tween was computed');
 
       interpolated = Tweenable.interpolate(
-        { x: 0 }, { x: 10 }, 1, 'linear', .5);
+        { x: 0 }, { x: 10 }, 1.5, 'linear', .5);
       equals(interpolated.x, 10, 'End of delayed tween was computed');
     });
 


### PR DESCRIPTION
Delays are tricky. We must remember that the actual position is tweenable position + startup delay, but the tweening only starts after
the initial startup position.