### PR TITLE
Don't stop a tween if it is not playing

### DIFF
--- a/src/shifty.core.js
+++ b/src/shifty.core.js
@@ -197,7 +197,7 @@ var Tweenable = (function () {
       applyFilter(tweenable, 'afterTween');
 
       step(currentState, tweenable._attachment, timeoutHandler_offset);
-    } else if (timeoutHandler_isEnded) {
+    } else if (tweenable.isPlaying() && timeoutHandler_isEnded) {
       step(targetState, tweenable._attachment, timeoutHandler_offset);
       tweenable.stop(true);
     }


### PR DESCRIPTION
As this method always `schedule` another pass on the next animation frame, it happens that some time pass (in laggy browser or at load time) and the time difference would led shifty to believe the animation is over when we actually paused the tween before it ends.

I had some issue tracking this bug down as it was flakey depending on how much the browser would block the main process.

Basically, this bug would appear when using `seek` at load time or on a low end device (laggy browser). The check for timeoutHandler_isEnded would just bump the animation to its end state.

-----

I'm not sure how we would unit test this bug as it's a pretty edge case behavior...