### PR TITLE
Fix strict mode injected by dependency manager.

### DIFF
--- a/src/shifty.intro.js
+++ b/src/shifty.intro.js
@@ -1,2 +1,2 @@
 ;(function () {
-  var root = this;
+  var root = this || Function('return this')();


### PR DESCRIPTION
Fall back to alternative technique for setting root to global scope if first attempt attempt fails due to strict mode being injected into top of module (e.g. by browserify).

http://stackoverflow.com/a/3277192.