### PR TITLE
[minor] Allow promise implementation to be configured.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-preset-es2015": "^6.22.0",
+    "bluebird": "^3.5.0",
     "gh-pages": "^0.12.0",
     "jsdoc": "^3.4.3",
     "jshint": "^2.9.4",

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -320,7 +320,8 @@ export class Tweenable {
       [currentState, this._originalState, this._targetState, this._easing];
     this._applyFilter('tweenCreated');
 
-    this._promise = new Promise(
+    const Promised = config.promise || Promise;
+    this._promise = new Promised(
       (resolve, reject) => {
         this._resolve = resolve;
         this._reject = reject;

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -285,6 +285,8 @@ export class Tweenable {
    * curve name(s) or function(s) to use for the tween.
    * @property {*=} config.attachment Cached value that is passed to the
    * `step`/`start` functions.
+   * @property {Function} config.promise Promise constructor for when you want
+   * to use Promise library or polyfill Promises in unsupported environments.
    * @return {Tweenable}
    */
   setConfig (config = {}) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 /* global describe:true, it:true, before:true, beforeEach:true, afterEach:true */
+import Promised from 'bluebird';
 import assert from 'assert';
 
 import {
@@ -387,6 +388,18 @@ describe('shifty', () => {
       });
 
       describe('promise support', () => {
+        it('supports third party libraries', function () {
+          const promised = tweenable.tween({
+            promise: Promised,
+
+            from: { x: 0 },
+            to: { x: 10  },
+            duration: 500
+          });
+
+          assert.ok(promised instanceof Promised);
+        });
+
         describe('resolution', () => {
           let testState;
 


### PR DESCRIPTION
This pull request introduces a new option, `promise` to the configuration chain. This option allows developers to:

- Manually provide a polyfill for Promise if the environment doesn't support it.
- Use third party promise libraries for debugging purposes for example bluebird supports long stack traces to aid debugging.
- Use libraries that introduce non-ES6 features like cancelable promises.