### PR TITLE
[#99] Revert "Fix `root` definition"

### DIFF
--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -5,8 +5,7 @@ import assign from 'object-assign';
 const DEFAULT_EASING = 'linear';
 const DEFAULT_DURATION = 500;
 const UPDATE_TIME = 1000 / 60;
-// jshint evil:true
-const root = new Function('return this')();
+const root = typeof window !== 'undefined' ? window : global;
 
 // requestAnimationFrame() shim by Paul Irish (modified for Shifty)
 // http://paulirish.com/2011/requestanimationframe-for-smart-animating/


### PR DESCRIPTION
This reverts commit 14facbeab37568eceeb043480a7a504f90c3d3e7.

I think this may have been incidentally fixed in a better way by upgrading to Webpack 2 (https://github.com/jeremyckahn/shifty/commit/dfdebd706cae01b849fafe4fbc93509d450fd9f8).  In any case, I think this is safe to revert.

@louh, could you please review this and make sure it fixes #99 for you?