### PR TITLE
Add typescript definitions generation

### DIFF
--- a/.jsdoc
+++ b/.jsdoc
@@ -1,5 +1,8 @@
 {
-  "plugins": ["plugins/markdown"],
+  "plugins": [
+    "plugins/markdown",
+    "./jsdoc-ts.js"
+  ],
   "opts": {
     "destination": "dist/doc",
     "readme": "index.md",

--- a/jsdoc-ts.js
+++ b/jsdoc-ts.js
@@ -1,0 +1,28 @@
+/**
+ * A small JSDoc plugin that replaces TSDoc (typescript flavored JSDoc)
+ * with regular JSDoc for not crashing documentation generation, while
+ * still having accurate types.
+ * @author arthuro555 <arthur.pacaud@hotmail.fr>
+ */
+
+const TYPESCRIPT_IMPORT_TYPE = /typedef {import\(.*\)/
+const TYPESCRIPT_RECORD_TYPE = /Record<.*,(.*)>/
+
+exports.astNodeVisitor = {
+  visitNode: function(node) {
+    if (node.type === 'File') {
+      if (node.comments) {
+        node.comments.forEach((/** @type {{ value: string }} */ comment) => {
+          // Remove imports as they are only necessary for typescript and crash jsdoc
+          if (TYPESCRIPT_IMPORT_TYPE.test(comment.value)) comment.value = ''
+
+          // Replace typescript Record<key, value> syntax with JSDoc Object.<value>
+          comment.value = comment.value.replace(
+            TYPESCRIPT_RECORD_TYPE,
+            `Object.<$1>`
+          )
+        })
+      }
+    }
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "shifty",
       "version": "2.16.0",
       "license": "MIT",
       "devDependencies": {
@@ -29,6 +30,7 @@
         "prettier": "^1.16.4",
         "pretty-quick": "^1.10.0",
         "serve": "^11.3.2",
+        "typescript": "^4.4.4",
         "webpack": "^5.11.0",
         "webpack-cli": "^4.2.0"
       }
@@ -1763,7 +1765,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -3455,13 +3456,13 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3601,7 +3602,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -4510,24 +4510,37 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dev": true,
       "dependencies": {
+        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.7.0",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-to-primitive": {
@@ -4571,8 +4584,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6034,9 +6046,9 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -6075,6 +6087,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-value": {
@@ -6286,6 +6314,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -6296,12 +6333,30 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-value": {
@@ -6628,6 +6683,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/interpret": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -6676,6 +6745,18 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6688,6 +6769,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -6695,12 +6792,15 @@
       "dev": true
     },
     "node_modules/is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -6869,6 +6969,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -6888,6 +7000,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number/node_modules/kind-of": {
@@ -6966,15 +7093,19 @@
       }
     },
     "node_modules/is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.1"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-retry-allowed": {
@@ -6986,6 +7117,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -6993,6 +7133,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-symbol": {
@@ -7012,6 +7167,18 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "node_modules/is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -7839,7 +8006,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10274,10 +10440,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -11841,6 +12010,20 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -12296,30 +12479,30 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       },
-      "engines": {
-        "node": ">= 0.4"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       },
-      "engines": {
-        "node": ">= 0.4"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -12967,6 +13150,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/typical": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
@@ -12981,6 +13177,21 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/undefsafe": {
       "version": "2.0.2",
@@ -13823,6 +14034,22 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-module": {
@@ -16987,13 +17214,13 @@
       }
     },
     "call-bind": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.0"
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caller-callsite": {
@@ -17852,21 +18079,31 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+      "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "get-symbol-description": "^1.0.0",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-inspect": "^1.7.0",
+        "has-symbols": "^1.0.2",
+        "internal-slot": "^1.0.3",
+        "is-callable": "^1.2.4",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.1",
+        "is-string": "^1.0.7",
+        "is-weakref": "^1.0.1",
+        "object-inspect": "^1.11.0",
         "object-keys": "^1.1.1",
-        "string.prototype.trimleft": "^2.1.0",
-        "string.prototype.trimright": "^2.1.0"
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -19113,9 +19350,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
-      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -19142,6 +19379,16 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "get-value": {
@@ -19315,6 +19562,12 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -19322,10 +19575,19 @@
       "dev": true
     },
     "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
       "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "has-value": {
       "version": "1.0.0",
@@ -19583,6 +19845,17 @@
         }
       }
     },
+    "internal-slot": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.0",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "interpret": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
@@ -19621,6 +19894,15 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
+    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -19630,6 +19912,16 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -19637,9 +19929,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
       "dev": true
     },
     "is-ci": {
@@ -19761,6 +20053,12 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+      "dev": true
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -19785,6 +20083,15 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "is-number-object": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+      "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-obj": {
@@ -19836,12 +20143,13 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.1"
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "is-retry-allowed": {
@@ -19850,11 +20158,26 @@
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
+    "is-shared-array-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+      "dev": true
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -19870,6 +20193,15 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
+    },
+    "is-weakref": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
+      "integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -22377,9 +22709,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+      "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
       "dev": true
     },
     "object-keys": {
@@ -23617,6 +23949,17 @@
       "dev": true,
       "optional": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -23997,24 +24340,24 @@
         "function-bind": "^1.0.2"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
-      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
-    "string.prototype.trimright": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
-      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "strip-ansi": {
@@ -24514,6 +24857,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
     "typical": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
@@ -24525,6 +24874,18 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
     },
     "undefsafe": {
       "version": "2.0.2",
@@ -25159,6 +25520,19 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "which-module": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "jest --watch",
     "ci": "npm run lint && jest",
     "doc": "jsdoc -c .jsdoc src/*.js",
-    "doc:view": "serve -s dist/doc",
+    "doc:view": "serve dist/doc",
     "doc:watch": "nodemon --exec \"npm run doc\" --watch src --watch ./ --ext js,md --ignore dist",
     "doc:live": "run-p doc:watch doc:view",
     "lint": "eslint src webpack.*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typegen": "tsc",
     "typegen:watch": "tsc --watch",
     "test": "jest --watch",
-    "ci": "npm run lint && jest",
+    "ci": "npm run lint && jest && tsc",
     "doc": "jsdoc -c .jsdoc src/*.js",
     "doc:view": "serve dist/doc",
     "doc:watch": "nodemon --exec \"npm run doc\" --watch src --watch ./ --ext js,md --ignore dist",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "description": "The fastest JavaScript animation engine on the web",
   "browser": "dist/shifty.js",
   "main": "dist/shifty.node.js",
+  "types": "./dist/index.d.ts",
   "devDependencies": {
     "@babel/core": "^7.12.10",
     "@babel/plugin-proposal-class-properties": "^7.12.1",
@@ -32,11 +33,14 @@
     "prettier": "^1.16.4",
     "pretty-quick": "^1.10.0",
     "serve": "^11.3.2",
+    "typescript": "^4.4.4",
     "webpack": "^5.11.0",
     "webpack-cli": "^4.2.0"
   },
   "scripts": {
     "build": "webpack",
+    "typegen": "tsc",
+    "typegen:watch": "tsc --watch",
     "test": "jest --watch",
     "ci": "npm run lint && jest",
     "doc": "jsdoc -c .jsdoc src/*.js",

--- a/src/bezier.js
+++ b/src/bezier.js
@@ -1,4 +1,5 @@
 import { Tweenable } from './tweenable'
+/** @typedef {import(".").shifty.easingFunction} shifty.easingFunction */
 
 /**
  * The Bezier magic in this file is adapted/copied almost wholesale from
@@ -152,18 +153,18 @@ const getCubicBezierTransition = (x1, y1, x2, y2) => pos =>
 
 /**
  * Create a Bezier easing function and attach it to {@link
- * shifty.Tweenable.formulas}.  This function gives you total control over the
+ * Tweenable.formulas}.  This function gives you total control over the
  * easing curve.  Matthew Lein's [Ceaser](http://matthewlein.com/ceaser/) is a
  * useful tool for visualizing the curves you can make with this function.
  * @method shifty.setBezierFunction
  * @param {string} name The name of the easing curve.  Overwrites the old
- * easing function on {@link shifty.Tweenable.formulas} if it exists.
+ * easing function on {@link Tweenable.formulas} if it exists.
  * @param {number} x1
  * @param {number} y1
  * @param {number} x2
  * @param {number} y2
  * @return {shifty.easingFunction} The {@link shifty.easingFunction} that was
- * attached to {@link shifty.Tweenable.formulas}.
+ * attached to {@link Tweenable.formulas}.
  */
 export const setBezierFunction = (name, x1, y1, x2, y2) => {
   const cubicBezierTransition = getCubicBezierTransition(x1, y1, x2, y2)
@@ -178,7 +179,7 @@ export const setBezierFunction = (name, x1, y1, x2, y2) => {
 }
 
 /**
- * `delete` an easing function from {@link shifty.Tweenable.formulas}.  Be
+ * `delete` an easing function from {@link Tweenable.formulas}.  Be
  * careful with this method, as it `delete`s whatever easing formula matches
  * `name` (which means you can delete standard Shifty easing functions).
  * @method shifty.unsetBezierFunction

--- a/src/easing-functions.js
+++ b/src/easing-functions.js
@@ -42,24 +42,32 @@
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const linear = pos => pos
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInQuad = pos => Math.pow(pos, 2)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutQuad = pos => -(Math.pow(pos - 1, 2) - 1)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutQuad = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 2) : -0.5 * ((pos -= 2) * pos - 2)
@@ -67,18 +75,24 @@ export const easeInOutQuad = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInCubic = pos => Math.pow(pos, 3)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutCubic = pos => Math.pow(pos - 1, 3) + 1
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutCubic = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 3) : 0.5 * (Math.pow(pos - 2, 3) + 2)
@@ -86,18 +100,24 @@ export const easeInOutCubic = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInQuart = pos => Math.pow(pos, 4)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutQuart = pos => -(Math.pow(pos - 1, 4) - 1)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutQuart = pos =>
   (pos /= 0.5) < 1
@@ -107,18 +127,24 @@ export const easeInOutQuart = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInQuint = pos => Math.pow(pos, 5)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutQuint = pos => Math.pow(pos - 1, 5) + 1
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutQuint = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 5) : 0.5 * (Math.pow(pos - 2, 5) + 2)
@@ -126,36 +152,48 @@ export const easeInOutQuint = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInSine = pos => -Math.cos(pos * (Math.PI / 2)) + 1
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutSine = pos => Math.sin(pos * (Math.PI / 2))
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutSine = pos => -0.5 * (Math.cos(Math.PI * pos) - 1)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInExpo = pos => (pos === 0 ? 0 : Math.pow(2, 10 * (pos - 1)))
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutExpo = pos => (pos === 1 ? 1 : -Math.pow(2, -10 * pos) + 1)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutExpo = pos => {
   if (pos === 0) {
@@ -176,18 +214,24 @@ export const easeInOutExpo = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInCirc = pos => -(Math.sqrt(1 - pos * pos) - 1)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutCirc = pos => Math.sqrt(1 - Math.pow(pos - 1, 2))
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutCirc = pos =>
   (pos /= 0.5) < 1
@@ -197,6 +241,8 @@ export const easeInOutCirc = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutBounce = pos => {
   if (pos < 1 / 2.75) {
@@ -213,6 +259,8 @@ export const easeOutBounce = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInBack = pos => {
   const s = 1.70158
@@ -222,6 +270,8 @@ export const easeInBack = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeOutBack = pos => {
   const s = 1.70158
@@ -231,6 +281,8 @@ export const easeOutBack = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeInOutBack = pos => {
   let s = 1.70158
@@ -243,6 +295,8 @@ export const easeInOutBack = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const elastic = pos =>
   -1 * Math.pow(4, -8 * pos) * Math.sin(((pos * 6 - 1) * (2 * Math.PI)) / 2) + 1
@@ -250,6 +304,8 @@ export const elastic = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const swingFromTo = pos => {
   let s = 1.70158
@@ -261,6 +317,8 @@ export const swingFromTo = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const swingFrom = pos => {
   const s = 1.70158
@@ -270,6 +328,8 @@ export const swingFrom = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const swingTo = pos => {
   const s = 1.70158
@@ -279,6 +339,8 @@ export const swingTo = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const bounce = pos => {
   if (pos < 1 / 2.75) {
@@ -295,6 +357,8 @@ export const bounce = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const bouncePast = pos => {
   if (pos < 1 / 2.75) {
@@ -311,6 +375,8 @@ export const bouncePast = pos => {
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeFromTo = pos =>
   (pos /= 0.5) < 1
@@ -320,11 +386,15 @@ export const easeFromTo = pos =>
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeFrom = pos => Math.pow(pos, 4)
 
 /**
  * @memberof Tweenable.formulas
  * @type {shifty.easingFunction}
+ * @param {number} pos
+ * @returns {number}
  */
 export const easeTo = pos => Math.pow(pos, 0.25)

--- a/src/easing-functions.js
+++ b/src/easing-functions.js
@@ -1,3 +1,5 @@
+/** @typedef {import(".").shifty.easingFunction} shifty.easingFunction */
+
 /*!
  * All equations are adapted from Thomas Fuchs'
  * [Scripty2](https://github.com/madrobby/scripty2/blob/master/src/effects/transitions/penner.js).
@@ -14,7 +16,7 @@
  */
 
 /**
- * @member shifty.Tweenable.formulas
+ * @member Tweenable.formulas
  * @description A static Object of {@link shifty.easingFunction}s that can by
  * used by Shifty. The default values are defined in
  * [`easing-functions.js`](easing-functions.js.html), but you can add your own
@@ -37,48 +39,124 @@
  * @static
  */
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const linear = pos => pos
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInQuad = pos => Math.pow(pos, 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutQuad = pos => -(Math.pow(pos - 1, 2) - 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutQuad = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 2) : -0.5 * ((pos -= 2) * pos - 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInCubic = pos => Math.pow(pos, 3)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutCubic = pos => Math.pow(pos - 1, 3) + 1
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutCubic = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 3) : 0.5 * (Math.pow(pos - 2, 3) + 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInQuart = pos => Math.pow(pos, 4)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutQuart = pos => -(Math.pow(pos - 1, 4) - 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutQuart = pos =>
   (pos /= 0.5) < 1
     ? 0.5 * Math.pow(pos, 4)
     : -0.5 * ((pos -= 2) * Math.pow(pos, 3) - 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInQuint = pos => Math.pow(pos, 5)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutQuint = pos => Math.pow(pos - 1, 5) + 1
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutQuint = pos =>
   (pos /= 0.5) < 1 ? 0.5 * Math.pow(pos, 5) : 0.5 * (Math.pow(pos - 2, 5) + 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInSine = pos => -Math.cos(pos * (Math.PI / 2)) + 1
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutSine = pos => Math.sin(pos * (Math.PI / 2))
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutSine = pos => -0.5 * (Math.cos(Math.PI * pos) - 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInExpo = pos => (pos === 0 ? 0 : Math.pow(2, 10 * (pos - 1)))
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutExpo = pos => (pos === 1 ? 1 : -Math.pow(2, -10 * pos) + 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutExpo = pos => {
   if (pos === 0) {
     return 0
@@ -95,15 +173,31 @@ export const easeInOutExpo = pos => {
   return 0.5 * (-Math.pow(2, -10 * --pos) + 2)
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInCirc = pos => -(Math.sqrt(1 - pos * pos) - 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutCirc = pos => Math.sqrt(1 - Math.pow(pos - 1, 2))
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutCirc = pos =>
   (pos /= 0.5) < 1
     ? -0.5 * (Math.sqrt(1 - pos * pos) - 1)
     : 0.5 * (Math.sqrt(1 - (pos -= 2) * pos) + 1)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutBounce = pos => {
   if (pos < 1 / 2.75) {
     return 7.5625 * pos * pos
@@ -116,16 +210,28 @@ export const easeOutBounce = pos => {
   }
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInBack = pos => {
   const s = 1.70158
   return pos * pos * ((s + 1) * pos - s)
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeOutBack = pos => {
   const s = 1.70158
   return (pos = pos - 1) * pos * ((s + 1) * pos + s) + 1
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeInOutBack = pos => {
   let s = 1.70158
   if ((pos /= 0.5) < 1) {
@@ -134,9 +240,17 @@ export const easeInOutBack = pos => {
   return 0.5 * ((pos -= 2) * pos * (((s *= 1.525) + 1) * pos + s) + 2)
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const elastic = pos =>
   -1 * Math.pow(4, -8 * pos) * Math.sin(((pos * 6 - 1) * (2 * Math.PI)) / 2) + 1
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const swingFromTo = pos => {
   let s = 1.70158
   return (pos /= 0.5) < 1
@@ -144,16 +258,28 @@ export const swingFromTo = pos => {
     : 0.5 * ((pos -= 2) * pos * (((s *= 1.525) + 1) * pos + s) + 2)
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const swingFrom = pos => {
   const s = 1.70158
   return pos * pos * ((s + 1) * pos - s)
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const swingTo = pos => {
   const s = 1.70158
   return (pos -= 1) * pos * ((s + 1) * pos + s) + 1
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const bounce = pos => {
   if (pos < 1 / 2.75) {
     return 7.5625 * pos * pos
@@ -166,6 +292,10 @@ export const bounce = pos => {
   }
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const bouncePast = pos => {
   if (pos < 1 / 2.75) {
     return 7.5625 * pos * pos
@@ -178,11 +308,23 @@ export const bouncePast = pos => {
   }
 }
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeFromTo = pos =>
   (pos /= 0.5) < 1
     ? 0.5 * Math.pow(pos, 4)
     : -0.5 * ((pos -= 2) * Math.pow(pos, 3) - 2)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeFrom = pos => Math.pow(pos, 4)
 
+/**
+ * @memberof Tweenable.formulas
+ * @type {shifty.easingFunction}
+ */
 export const easeTo = pos => Math.pow(pos, 0.25)

--- a/src/index.js
+++ b/src/index.js
@@ -23,43 +23,47 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  */
 
 /**
- * @callback {Function} shifty.easingFunction
+ * @callback shifty.easingFunction
  * @param {number} position The normalized (0-1) position of the tween.
  * @return {number} The curve-adjusted value.
  */
 
 /**
- * @callback {Function} shifty.startFunction
+ * @callback shifty.startFunction
  * @param {Object} state The current state of the tween.
  * @param {Object|undefined} [data] User-defined data provided via a {@link
  * shifty.tweenConfig}.
+ * @returns {void}
  */
 
 /**
- * @callback {Function} shifty.finishFunction
+ * @callback shifty.finishFunction
  * @param {shifty.promisedData} promisedData
+ * @returns {void}
  */
 
 /**
  * Gets called for every tick of the tween.  This function is not called on the
  * final tick of the animation.
- * @callback {Function} shifty.renderFunction
+ * @callback shifty.renderFunction
  * @param {Object} state The current state of the tween.
- * @param {Object|undefined} [data] User-defined data provided via a {@link
+ * @param {Object|undefined} data User-defined data provided via a {@link
  * shifty.tweenConfig}.
  * @param {number} timeElapsed The time elapsed since the start of the tween.
+ * @returns {void}
  */
 
 /**
  * @callback shifty.scheduleFunction
  * @param {Function} callback
  * @param {number} timeout
+ * @returns {void}
  */
 
 /**
  * @typedef {Object} shifty.tweenConfig
  * @property {Object} [from] Starting position.  If omitted, {@link
- * shifty.Tweenable#get} is used.
+ * Tweenable#get} is used.
  * @property {Object} [to] Ending position.  The keys of this Object should
  * match those of `to`.
  * @property {number} [duration] How many milliseconds to animate for.
@@ -67,8 +71,8 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * tween.
  * @property {shifty.startFunction} [start] Executes when the tween begins.
  * @property {shifty.finishFunction} [finish] Executes when the tween
- * completes. This will get overridden by {@link shifty.Tweenable#then} if that
- * is called, and it will not fire if {@link shifty.Tweenable#cancel} is
+ * completes. This will get overridden by {@link Tweenable#then} if that
+ * is called, and it will not fire if {@link Tweenable#cancel} is
  * called.
  * @property {shifty.renderFunction} [render] Executes on every tick. Shifty
  * assumes a [retained mode](https://en.wikipedia.org/wiki/Retained_mode)
@@ -80,9 +84,8 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * custom environments such as `<canvas>`.
  *
  * Legacy property name: `step`.
- * @property
- * {Object.<string|shifty.easingFunction>|string|shifty.easingFunction}
- * [easing] Easing curve name(s) or {@link shifty.easingFunction}(s) to apply
+ * @property {Object<string|shifty.easingFunction>|string|shifty.easingFunction} [easing]
+ * Easing curve name(s) or {@link shifty.easingFunction}(s) to apply
  * to the properties of the tween.  If this is an Object, the keys should
  * correspond to `to`/`from`.  You can learn more about this in the {@tutorial
  * easing-function-in-depth} tutorial.
@@ -97,7 +100,7 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * @typedef {Object} shifty.promisedData
  * @property {Object} state The current state of the tween.
  * @property {Object} data The `data` Object that the tween was configured with.
- * @property {shifty.Tweenable} tweenable The {@link shifty.Tweenable} instance to
+ * @property {Tweenable} tweenable The {@link Tweenable} instance to
  * which the tween belonged.
  */
 
@@ -105,8 +108,8 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * Is called when a tween is created to determine if a filter is needed.
  * Filters are only added to a tween when it is created so that they are not
  * unnecessarily processed if they don't apply during an update tick.
- * @callback {Function} shifty.doesApplyFilter
- * @param {shifty.Tweenable} tweenable The {@link shifty.Tweenable} instance.
+ * @callback shifty.doesApplyFilter
+ * @param {Tweenable} tweenable The {@link Tweenable} instance.
  * @return {boolean}
  */
 
@@ -114,20 +117,23 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * Is called when a tween is created.  This should perform any setup needed by
  * subsequent per-tick calls to {@link shifty.beforeTween} and {@link
  * shifty.afterTween}.
- * @callback {Function} shifty.tweenCreatedFilter
- * @param {shifty.Tweenable} tweenable The {@link shifty.Tweenable} instance.
+ * @callback shifty.tweenCreatedFilter
+ * @param {Tweenable} tweenable The {@link Tweenable} instance.
+ * @returns {void}
  */
 
 /**
  * Is called right before a tween is processed in a tick.
- * @callback {Function} shifty.beforeTweenFilter
- * @param {shifty.Tweenable} tweenable The {@link shifty.Tweenable} instance.
+ * @callback shifty.beforeTweenFilter
+ * @param {Tweenable} tweenable The {@link Tweenable} instance.
+ * @returns {void}
  */
 
 /**
  * Is called right after a tween is processed in a tick.
- * @callback {Function} shifty.afterTweenFilter
- * @param {shifty.Tweenable} tweenable The {@link shifty.Tweenable} instance.
+ * @callback shifty.afterTweenFilter
+ * @param {Tweenable} tweenable The {@link Tweenable} instance.
+ * @returns {void}
  */
 
 /**

--- a/src/interpolate.js
+++ b/src/interpolate.js
@@ -1,4 +1,5 @@
 import { Tweenable, composeEasingObject, tweenProps } from './tweenable'
+/** @typedef {import("./index").shifty.easingFunction} shifty.easingFunction */
 
 // Fake a Tweenable and patch some internals.  This approach allows us to
 // skip uneccessary processing and object recreation, cutting down on garbage
@@ -8,7 +9,7 @@ const { filters } = Tweenable
 
 /**
  * Compute the midpoint of two Objects.  This method effectively calculates a
- * specific frame of animation that {@link shifty.Tweenable#tween} does many times
+ * specific frame of animation that {@link Tweenable#tween} does many times
  * over the course of a full tween.
  *
  * ```
@@ -30,21 +31,22 @@ const { filters } = Tweenable
  * ```
  *
  * @method shifty.interpolate
- * @param {Object} from The starting values to tween from.
- * @param {Object} to The ending values to tween to.
+ * @template T
+ * @param {T} from The starting values to tween from.
+ * @param {T} to The ending values to tween to.
  * @param {number} position The normalized position value (between `0.0` and
  * `1.0`) to interpolate the values between `from` and `to` for.  `from`
  * represents `0` and `to` represents `1`.
- * @param {Object.<string|shifty.easingFunction>|string|shifty.easingFunction}
- * easing The easing curve(s) to calculate the midpoint against.  You can
- * reference any easing function attached to {@link shifty.Tweenable.formulas},
+ * @param {Record<string, string | shifty.easingFunction> | string | shifty.easingFunction} easing
+ * The easing curve(s) to calculate the midpoint against.  You can
+ * reference any easing function attached to {@link Tweenable.formulas},
  * or provide the {@link shifty.easingFunction}(s) directly.  If omitted, this
  * defaults to "linear".
  * @param {number} [delay=0] Optional delay to pad the beginning of the
  * interpolated tween with.  This increases the range of `position` from (`0`
  * through `1`) to (`0` through `1 + delay`).  So, a delay of `0.5` would
  * increase all valid values of `position` to numbers between `0` and `1.5`.
- * @return {Object}
+ * @return {T}
  */
 export const interpolate = (from, to, position, easing, delay = 0) => {
   const current = { ...from }

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,4 +1,5 @@
 /** @typedef {import("./tweenable").Tweenable} Tweenable */
+
 export class Scene {
   #tweenables = []
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -1,10 +1,11 @@
+/** @typedef {import("./tweenable").Tweenable} Tweenable */
 export class Scene {
   #tweenables = []
 
   /**
-   * The {@link shifty.Scene} class provides a way to control groups of {@link
-   * shifty.Tweenable}s. It is lightweight, minimalistic, and meant to provide
-   * performant {@link shifty.Tweenable} batch control that users of Shifty
+   * The {@link Scene} class provides a way to control groups of {@link
+   * Tweenable}s. It is lightweight, minimalistic, and meant to provide
+   * performant {@link Tweenable} batch control that users of Shifty
    * might otherwise have to implement themselves. It is **not** a robust
    * timeline solution, and it does **not** provide utilities for sophisticated
    * animation sequencing or orchestration. If that is what you need for your
@@ -12,10 +13,10 @@ export class Scene {
    * [Rekapi](http://jeremyckahn.github.io/rekapi/doc/) (a timeline layer built
    * on top of Shifty).
    *
-   * Please be aware that {@link shifty.Scene} does **not** perform any
-   * automatic cleanup. If you want to remove a {@link shifty.Tweenable} from a
-   * {@link shifty.Scene}, you must do so explicitly with either {@link
-   * shifty.Scene#remove} or {@link shifty.Scene#empty}.
+   * Please be aware that {@link Scene} does **not** perform any
+   * automatic cleanup. If you want to remove a {@link Tweenable} from a
+   * {@link Scene}, you must do so explicitly with either {@link
+   * Scene#remove} or {@link Scene#empty}.
    *
    * <p class="codepen" data-height="677" data-theme-id="0" data-default-tab="js,result" data-user="jeremyckahn" data-slug-hash="qvZKbe" style="height: 677px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid black; margin: 1em 0; padding: 1em;" data-pen-title="Shifty Scene Demo">
    * <span>See the Pen <a href="https://codepen.io/jeremyckahn/pen/qvZKbe/">
@@ -23,29 +24,29 @@ export class Scene {
    * on <a href="https://codepen.io">CodePen</a>.</span>
    * </p>
    * <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
-   * @param {...shifty.Tweenable} tweenables
+   * @param {...Tweenable} tweenables
    * @see https://codepen.io/jeremyckahn/pen/qvZKbe
-   * @constructs shifty.Scene
+   * @constructs Scene
+   * @memberof shifty
    */
   constructor(...tweenables) {
     tweenables.forEach(this.add.bind(this))
   }
 
   /**
-   * A copy of the internal {@link shifty.Tweenable}s array.
-   * @member shifty.Scene#tweenables
-   * @type {Array.<shifty.Tweenable>}
-   * @readonly
+   * A copy of the internal {@link Tweenable}s array.
+   * @member Scene#tweenables
+   * @type {Array.<Tweenable>}
    */
   get tweenables() {
     return [...this.#tweenables]
   }
 
   /**
-   * The {@link external:Promise}s for all {@link shifty.Tweenable}s in this
-   * {@link shifty.Scene} that have been configured with {@link
-   * shifty.Tweenable#setConfig}. Note that each call of {@link
-   * shifty.Scene#play} or {@link shifty.Scene#pause} creates new {@link
+   * The {@link external:Promise}s for all {@link Tweenable}s in this
+   * {@link Scene} that have been configured with {@link
+   * Tweenable#setConfig}. Note that each call of {@link
+   * Scene#play} or {@link Scene#pause} creates new {@link
    * external:Promise}s:
    *
    *     const scene = new Scene(new Tweenable());
@@ -57,20 +58,19 @@ export class Scene {
    *       scene.play()
    *     );
    *
-   * @member shifty.Scene#promises
-   * @type {Array.<external:Promise>}
-   * @readonly
+   * @member Scene#promises
+   * @type {Array.<Promise<any>>}
    */
   get promises() {
     return this.#tweenables.map(tweenable => tweenable.then())
   }
 
   /**
-   * Add a {@link shifty.Tweenable} to be controlled by this {@link
-   * shifty.Scene}.
-   * @method shifty.Scene#add
-   * @param {shifty.Tweenable} tweenable
-   * @return {shifty.Tweenable} The {@link shifty.Tweenable} that was added.
+   * Add a {@link Tweenable} to be controlled by this {@link
+   * Scene}.
+   * @method Scene#add
+   * @param {Tweenable} tweenable
+   * @return {Tweenable} The {@link Tweenable} that was added.
    */
   add(tweenable) {
     this.#tweenables.push(tweenable)
@@ -79,11 +79,11 @@ export class Scene {
   }
 
   /**
-   * Remove a {@link shifty.Tweenable} that is controlled by this {@link
-   * shifty.Scene}.
-   * @method shifty.Scene#remove
-   * @param {shifty.Tweenable} tweenable
-   * @return {shifty.Tweenable} The {@link shifty.Tweenable} that was removed.
+   * Remove a {@link Tweenable} that is controlled by this {@link
+   * Scene}.
+   * @method Scene#remove
+   * @param {Tweenable} tweenable
+   * @return {Tweenable} The {@link Tweenable} that was removed.
    */
   remove(tweenable) {
     const index = this.#tweenables.indexOf(tweenable)
@@ -96,10 +96,10 @@ export class Scene {
   }
 
   /**
-   * [Remove]{@link shifty.Scene#remove} all {@link shifty.Tweenable}s in this {@link
-   * shifty.Scene}.
-   * @method shifty.Scene#empty
-   * @return {Array.<shifty.Tweenable>} The {@link shifty.Tweenable}s that were
+   * [Remove]{@link Scene#remove} all {@link Tweenable}s in this {@link
+   * Scene}.
+   * @method Scene#empty
+   * @return {Array.<Tweenable>} The {@link Tweenable}s that were
    * removed.
    */
   empty() {
@@ -108,9 +108,9 @@ export class Scene {
   }
 
   /**
-   * Is `true` if any {@link shifty.Tweenable} in this {@link shifty.Scene} is
+   * Is `true` if any {@link Tweenable} in this {@link Scene} is
    * playing.
-   * @method shifty.Scene#isPlaying
+   * @method Scene#isPlaying
    * @return {boolean}
    */
   isPlaying() {
@@ -118,9 +118,9 @@ export class Scene {
   }
 
   /**
-   * Play all {@link shifty.Tweenable}s from their beginning.
-   * @method shifty.Scene#play
-   * @return {shifty.Scene}
+   * Play all {@link Tweenable}s from their beginning.
+   * @method Scene#play
+   * @return {Scene}
    */
   play() {
     this.#tweenables.forEach(tweenable => tweenable.tween())
@@ -129,10 +129,10 @@ export class Scene {
   }
 
   /**
-   * {@link shifty.Tweenable#pause} all {@link shifty.Tweenable}s in this
-   * {@link shifty.Scene}.
-   * @method shifty.Scene#pause
-   * @return {shifty.Scene}
+   * {@link Tweenable#pause} all {@link Tweenable}s in this
+   * {@link Scene}.
+   * @method Scene#pause
+   * @return {Scene}
    */
   pause() {
     this.#tweenables.forEach(tweenable => tweenable.pause())
@@ -140,9 +140,9 @@ export class Scene {
   }
 
   /**
-   * {@link shifty.Tweenable#resume} all paused {@link shifty.Tweenable}s.
-   * @method shifty.Scene#resume
-   * @return {shifty.Scene}
+   * {@link Tweenable#resume} all paused {@link Tweenable}s.
+   * @method Scene#resume
+   * @return {Scene}
    */
   resume() {
     this.#tweenables.forEach(tweenable => tweenable.resume())
@@ -151,11 +151,11 @@ export class Scene {
   }
 
   /**
-   * {@link shifty.Tweenable#stop} all {@link shifty.Tweenable}s in this {@link
-   * shifty.Scene}.
-   * @method shifty.Scene#stop
+   * {@link Tweenable#stop} all {@link Tweenable}s in this {@link
+   * Scene}.
+   * @method Scene#stop
    * @param {boolean} [gotoEnd]
-   * @return {shifty.Scene}
+   * @return {Scene}
    */
   stop(gotoEnd) {
     this.#tweenables.forEach(tweenable => tweenable.stop(gotoEnd))

--- a/src/token.js
+++ b/src/token.js
@@ -355,6 +355,7 @@ const collapseEasingObject = (easingObject, tokenData) => {
 /**
  * @memberof Tweenable.filters.token
  * @param {Tweenable} tweenable
+ * @returns {boolean}
  */
 export const doesApply = tweenable => {
   for (const key in tweenable._currentState) {

--- a/src/token.js
+++ b/src/token.js
@@ -1,3 +1,5 @@
+/** @typedef {import("./tweenable").Tweenable} Tweenable */
+
 const R_NUMBER_COMPONENT = /(\d|-|\.)/
 const R_FORMAT_CHUNKS = /([^\-0-9.]+)/g
 const R_UNFORMATTED_VALUES = /[0-9.-]+/g
@@ -350,6 +352,10 @@ const collapseEasingObject = (easingObject, tokenData) => {
   }
 }
 
+/**
+ * @memberof Tweenable.filters.token
+ * @param {Tweenable} tweenable
+ */
 export const doesApply = tweenable => {
   for (const key in tweenable._currentState) {
     if (typeof tweenable._currentState[key] === 'string') {
@@ -360,6 +366,10 @@ export const doesApply = tweenable => {
   return false
 }
 
+/**
+ * @memberof Tweenable.filters.token
+ * @param {Tweenable} tweenable
+ */
 export function tweenCreated(tweenable) {
   const { _currentState, _originalState, _targetState } = tweenable
 
@@ -370,6 +380,10 @@ export function tweenCreated(tweenable) {
   tweenable._tokenData = getFormatSignatures(_currentState)
 }
 
+/**
+ * @memberof Tweenable.filters.token
+ * @param {Tweenable} tweenable
+ */
 export function beforeTween(tweenable) {
   const {
     _currentState,
@@ -385,6 +399,10 @@ export function beforeTween(tweenable) {
   )
 }
 
+/**
+ * @memberof Tweenable.filters.token
+ * @param {Tweenable} tweenable
+ */
 export function afterTween(tweenable) {
   const {
     _currentState,

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -1,4 +1,8 @@
 import * as easingFunctions from './easing-functions'
+import * as token from './token'
+/** @typedef {import("./index").shifty.filter} shifty.filter */
+/** @typedef {import("./index").shifty.tweenConfig} shifty.tweenConfig */
+/** @typedef {import("./index").shifty.scheduleFunction} shifty.scheduleFunction */
 
 // CONSTANTS
 const DEFAULT_EASING = 'linear'
@@ -28,9 +32,25 @@ const noop = () => {}
 let listHead = null
 let listTail = null
 
-// Strictly used for testing
+/**
+ * Strictly for testing.
+ * @private
+ * @internal
+ */
 export const resetList = () => (listHead = listTail = null)
+
+/**
+ * Strictly for testing.
+ * @private
+ * @internal
+ */
 export const getListHead = () => listHead
+
+/**
+ * Strictly for testing.
+ * @private
+ * @internal
+ */
 export const getListTail = () => listTail
 
 const formulas = { ...easingFunctions }
@@ -46,7 +66,7 @@ const formulas = { ...easingFunctions }
  * is tweening to.
  * @param {number} duration: The length of the tween in milliseconds.
  * @param {number} timestamp: The UNIX epoch time at which the tween began.
- * @param {Object<string|Function>} easing: This Object's keys must correspond
+ * @param {Record<string, string|Function>} easing: This Object's keys must correspond
  * to the keys in targetState.
  * @returns {Object}
  * @private
@@ -152,13 +172,13 @@ const processTween = (tween, currentTime) => {
  * run *by* the scheduling functionality. Specifically, it computes the state
  * and calls all of the relevant {@link shifty.tweenConfig} functions supplied
  * to each of the tweens for the current point in time (as determined by {@link
- * shifty.Tweenable.now}.
+ * Tweenable.now}.
  *
  * This is a low-level API that won't be needed in the majority of situations.
  * It is primarily useful as a hook for higher-level animation systems that are
  * built on top of Shifty. If you need this function, it is likely you need to
  * pass something like `() => {}` to {@link
- * shifty.Tweenable.setScheduleFunction}, override {@link shifty.Tweenable.now}
+ * Tweenable.setScheduleFunction}, override {@link Tweenable.now}
  * and manage the scheduling logic yourself.
  *
  * @method shifty.processTweens
@@ -183,7 +203,7 @@ let now
 /**
  * Handles the update logic for one tick of a tween.
  * @param {number} [currentTimeOverride] Needed for accurate timestamp in
- * shifty.Tweenable#seek.
+ * Tweenable#seek.
  * @private
  */
 export const scheduleUpdate = () => {
@@ -200,10 +220,10 @@ export const scheduleUpdate = () => {
  *
  * If the tween has only one easing across all properties, that function is
  * returned directly.
- * @param {Object.<string|Function>} fromTweenParams
+ * @param {Record<string, string|Function>} fromTweenParams
  * @param {Object|string|Function} [easing]
  * @param {Object} [composedEasing] Reused composedEasing object (used internally)
- * @return {Object.<string|Function>|Function}
+ * @return {Record<string, string|Function>|Function}
  * @private
  */
 export const composeEasingObject = (
@@ -267,7 +287,7 @@ const defaultPromiseCtor = typeof Promise === 'function' ? Promise : null
 
 export class Tweenable {
   /**
-   * @method shifty.Tweenable.now
+   * @method Tweenable.now
    * @static
    * @returns {number} The current timestamp.
    */
@@ -276,26 +296,42 @@ export class Tweenable {
   /**
    * @param {Object} [initialState={}] The values that the initial tween should
    * start at if a `from` value is not provided to {@link
-   * shifty.Tweenable#tween} or {@link shifty.Tweenable#setConfig}.
+   * Tweenable#tween} or {@link Tweenable#setConfig}.
    * @param {shifty.tweenConfig} [config] Configuration object to be passed to
-   * {@link shifty.Tweenable#setConfig}.
-   * @constructs shifty.Tweenable
+   * {@link Tweenable#setConfig}.
+   * @constructs Tweenable
+   * @memberof shifty
    */
   constructor(initialState = {}, config = undefined) {
+    /** @private */
     this._config = {}
+    /** @private */
     this._data = {}
+    /** @private */
     this._delay = 0
+    /** @private */
     this._filters = []
+    /** @private */
     this._next = null
+    /** @private */
     this._previous = null
+    /** @private */
     this._timestamp = null
+    /** @private */
     this._resolve = null
+    /** @private */
     this._reject = null
+    /** @private */
     this._currentState = initialState || {}
+    /** @private */
     this._originalState = {}
+    /** @private */
     this._targetState = {}
+    /** @private */
     this._start = noop
+    /** @private */
     this._render = noop
+    /** @private */
     this._promiseCtor = defaultPromiseCtor
 
     // To prevent unnecessary calls to setConfig do not set default
@@ -323,13 +359,13 @@ export class Tweenable {
   }
 
   /**
-   * Configure and start a tween. If this {@link shifty.Tweenable}'s instance
+   * Configure and start a tween. If this {@link Tweenable}'s instance
    * is already running, then it will stop playing the old tween and
    * immediately play the new one.
-   * @method shifty.Tweenable#tween
+   * @method Tweenable#tween
    * @param {shifty.tweenConfig} [config] Gets passed to {@link
-   * shifty.Tweenable#setConfig}.
-   * @return {shifty.Tweenable}
+   * Tweenable#setConfig}.
+   * @return {Tweenable}
    */
   tween(config = undefined) {
     if (this._isPlaying) {
@@ -340,6 +376,7 @@ export class Tweenable {
       this.setConfig(config)
     }
 
+    /** @private */
     this._pausedAtTime = null
     this._timestamp = Tweenable.now()
     this._start(this.get(), this._data)
@@ -355,10 +392,10 @@ export class Tweenable {
    * Configure a tween that will start at some point in the future. Aside from
    * `delay`, `from`, and `to`, each configuration option will automatically
    * default to the same option used in the preceding tween of this {@link
-   * shifty.Tweenable} instance.
-   * @method shifty.Tweenable#setConfig
+   * Tweenable} instance.
+   * @method Tweenable#setConfig
    * @param {shifty.tweenConfig} [config={}]
-   * @return {shifty.Tweenable}
+   * @return {Tweenable}
    */
   setConfig(config = {}) {
     const { _config } = this
@@ -383,13 +420,21 @@ export class Tweenable {
     this._data = _config.data || _config.attachment || this._data
 
     // Init the internal state
+    /** @private */
     this._isPlaying = false
+    /** @private */
     this._pausedAtTime = null
+    /** @private */
     this._scheduleId = null
+    /** @private */
     this._delay = config.delay || 0
+    /** @private */
     this._start = start
+    /** @private */
     this._render = render || step
+    /** @private */
     this._duration = _config.duration || DEFAULT_DURATION
+    /** @private */
     this._promiseCtor = promise
 
     if (finish) {
@@ -418,6 +463,7 @@ export class Tweenable {
       _targetState[key] = to.hasOwnProperty(key) ? to[key] : currentProp
     }
 
+    /** @private */
     this._easing = composeEasingObject(
       this._currentState,
       _config.easing,
@@ -441,15 +487,16 @@ export class Tweenable {
 
   /**
    * Overrides any `finish` function passed via a {@link shifty.tweenConfig}.
-   * @method shifty.Tweenable#then
+   * @method Tweenable#then
    * @param {function} onFulfilled Receives {@link shifty.promisedData} as the
    * first parameter.
    * @param {function} onRejected Receives {@link shifty.promisedData} as the
    * first parameter.
-   * @return {external:Promise}
+   * @return {Promise<Object>}
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
    */
   then(onFulfilled, onRejected) {
+    /** @private */
     this._promise = new this._promiseCtor((resolve, reject) => {
       this._resolve = resolve
       this._reject = reject
@@ -459,10 +506,10 @@ export class Tweenable {
   }
 
   /**
-   * @method shifty.Tweenable#catch
+   * @method Tweenable#catch
    * @param {function} onRejected Receives {@link shifty.promisedData} as the
    * first parameter.
-   * @return {external:Promise}
+   * @return {Promise<Object>}
    * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
    */
   catch(onRejected) {
@@ -470,7 +517,7 @@ export class Tweenable {
   }
 
   /**
-   * @method shifty.Tweenable#get
+   * @method Tweenable#get
    * @return {Object} The current state.
    */
   get() {
@@ -479,7 +526,7 @@ export class Tweenable {
 
   /**
    * Set the current state.
-   * @method shifty.Tweenable#set
+   * @method Tweenable#set
    * @param {Object} state The state to set.
    */
   set(state) {
@@ -489,8 +536,8 @@ export class Tweenable {
   /**
    * Pause a tween. Paused tweens can be resumed from the point at which they
    * were paused. If a tween is not running, this is a no-op.
-   * @method shifty.Tweenable#pause
-   * @return {shifty.Tweenable}
+   * @method Tweenable#pause
+   * @return {Tweenable}
    */
   pause() {
     if (!this._isPlaying) {
@@ -506,13 +553,14 @@ export class Tweenable {
 
   /**
    * Resume a paused tween.
-   * @method shifty.Tweenable#resume
-   * @return {shifty.Tweenable}
+   * @method Tweenable#resume
+   * @return {Tweenable}
    */
   resume() {
     return this._resume()
   }
 
+  /** @private */
   _resume(currentTime = Tweenable.now()) {
     if (this._timestamp === null) {
       return this.tween()
@@ -546,10 +594,10 @@ export class Tweenable {
    * Move the state of the animation to a specific point in the tween's
    * timeline.  If the animation is not running, this will cause {@link
    * shifty.renderFunction} handlers to be called.
-   * @method shifty.Tweenable#seek
-   * @param {millisecond} millisecond The millisecond of the animation to seek
+   * @method Tweenable#seek
+   * @param {number} millisecond The millisecond of the animation to seek
    * to.  This must not be less than `0`.
-   * @return {shifty.Tweenable}
+   * @return {Tweenable}
    */
   seek(millisecond) {
     millisecond = Math.max(millisecond, 0)
@@ -570,12 +618,12 @@ export class Tweenable {
   /**
    * Stops a tween. If a tween is not running, this is a no-op. This method
    * does not cancel the tween {@link external:Promise}. For that, use {@link
-   * shifty.Tweenable#cancel}.
+   * Tweenable#cancel}.
    * @param {boolean} [gotoEnd] If `false`, the tween just stops at its current
    * state.  If `true`, the tweened object's values are instantly set to the
    * target values.
-   * @method shifty.Tweenable#stop
-   * @return {shifty.Tweenable}
+   * @method Tweenable#stop
+   * @return {Tweenable}
    */
   stop(gotoEnd = false) {
     if (!this._isPlaying) {
@@ -624,12 +672,12 @@ export class Tweenable {
   }
 
   /**
-   * {@link shifty.Tweenable#stop}s a tween and also `reject`s its {@link
+   * {@link Tweenable#stop}s a tween and also `reject`s its {@link
    * external:Promise}. If a tween is not running, this is a no-op. Prevents
    * calling any provided `finish` function.
-   * @param {boolean} [gotoEnd] Is propagated to {@link shifty.Tweenable#stop}.
-   * @method shifty.Tweenable#cancel
-   * @return {shifty.Tweenable}
+   * @param {boolean} [gotoEnd] Is propagated to {@link Tweenable#stop}.
+   * @method Tweenable#cancel
+   * @return {Tweenable}
    * @see https://github.com/jeremyckahn/shifty/issues/122
    */
   cancel(gotoEnd = false) {
@@ -655,7 +703,7 @@ export class Tweenable {
 
   /**
    * Whether or not a tween is running.
-   * @method shifty.Tweenable#isPlaying
+   * @method Tweenable#isPlaying
    * @return {boolean}
    */
   isPlaying() {
@@ -663,9 +711,9 @@ export class Tweenable {
   }
 
   /**
-   * @method shifty.Tweenable#setScheduleFunction
+   * @method Tweenable#setScheduleFunction
    * @param {shifty.scheduleFunction} scheduleFunction
-   * @deprecated Will be removed in favor of {@link shifty.Tweenable.setScheduleFunction} in 3.0.
+   * @deprecated Will be removed in favor of {@link Tweenable.setScheduleFunction} in 3.0.
    */
   setScheduleFunction(scheduleFunction) {
     Tweenable.setScheduleFunction(scheduleFunction)
@@ -676,7 +724,7 @@ export class Tweenable {
    * shifty.promisedData}, {@link shifty.startFunction} and {@link
    * shifty.renderFunction}.
    * @param {Object} [data]
-   * @method shifty.Tweenable#data
+   * @method Tweenable#data
    * @return {Object} The internally stored `data`.
    */
   data(data = null) {
@@ -689,8 +737,8 @@ export class Tweenable {
 
   /**
    * `delete` all "own" properties.  Call this when the {@link
-   * shifty.Tweenable} instance is no longer needed to free memory.
-   * @method shifty.Tweenable#dispose
+   * Tweenable} instance is no longer needed to free memory.
+   * @method Tweenable#dispose
    */
   dispose() {
     for (const prop in this) {
@@ -709,7 +757,7 @@ export class Tweenable {
  * is used if available, otherwise
  * [`setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/Window.setTimeout)
  * is used.
- * @method shifty.Tweenable.setScheduleFunction
+ * @method Tweenable.setScheduleFunction
  * @param {shifty.scheduleFunction} fn The function to be
  * used to schedule the next frame to be rendered.
  * @return {shifty.scheduleFunction} The function that was set.
@@ -722,8 +770,8 @@ Tweenable.formulas = formulas
  * The {@link shifty.filter}s available for use.  These filters are
  * automatically applied at tween-time by Shifty. You can define your own
  * {@link shifty.filter}s and attach them to this object.
- * @member shifty.Tweenable.filters
- * @type {Object.<shifty.filter>}
+ * @member Tweenable.filters
+ * @type {Record<string, shifty.filter>}
  */
 Tweenable.filters = {}
 
@@ -731,8 +779,8 @@ Tweenable.filters = {}
  * @method shifty.tween
  * @param {shifty.tweenConfig} [config={}]
  * @description Standalone convenience method that functions identically to
- * {@link shifty.Tweenable#tween}.  You can use this to create tweens without
- * needing to set up a {@link shifty.Tweenable} instance.
+ * {@link Tweenable#tween}.  You can use this to create tweens without
+ * needing to set up a {@link Tweenable} instance.
  *
  * ```
  * import { tween } from 'shifty';
@@ -742,7 +790,7 @@ Tweenable.filters = {}
  * );
  * ```
  *
- * @returns {shifty.Tweenable} A new {@link shifty.Tweenable} instance.
+ * @returns {Tweenable} A new {@link Tweenable} instance.
  */
 export function tween(config = {}) {
   const tweenable = new Tweenable()

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -1,5 +1,4 @@
 import * as easingFunctions from './easing-functions'
-import * as token from './token'
 /** @typedef {import("./index").shifty.filter} shifty.filter */
 /** @typedef {import("./index").shifty.tweenConfig} shifty.tweenConfig */
 /** @typedef {import("./index").shifty.scheduleFunction} shifty.scheduleFunction */
@@ -37,10 +36,13 @@ let listTail = null
  * @private
  * @internal
  */
-export const resetList = () => (listHead = listTail = null)
+export const resetList = () => {
+  listHead = listTail = null
+}
 
 /**
  * Strictly for testing.
+ * @returns {Tweenable}
  * @private
  * @internal
  */
@@ -48,6 +50,7 @@ export const getListHead = () => listHead
 
 /**
  * Strictly for testing.
+ * @returns {Tweenable}
  * @private
  * @internal
  */
@@ -560,7 +563,11 @@ export class Tweenable {
     return this._resume()
   }
 
-  /** @private */
+  /**
+   * @private
+   * @param {number} currentTime
+   * @returns {Tweenable}
+   */
   _resume(currentTime = Tweenable.now()) {
     if (this._timestamp === null) {
       return this.tween()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "include": ["./src/index.js", "./src/index.core.js"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // By uncommenting this, you can enable typescript typechecking on the library code,
+    // but that is not necessary to the generation of type definitions.
+    //"checkJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // Generate maps to go to the source code from a definition
+    "declarationMap": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go into this directory.
+    // Removing this would place the .d.ts files
+    // next to the .js files
+    "outDir": "dist"
+  }
+}


### PR DESCRIPTION
This adds automatic generation of TypeScript type definition files for shifty from the JSDoc comments.
There are a few issues:

 - Some JSDoc comments are correctly recognized and parsed by both tsc and jsdoc, but make eslint's valid-jsdoc rule complain
 - Some TSDoc syntax (TypeScript superset of JSDoc, like type imports & record type) are unsupported by JSDoc and eslint (I have made a minimal plugin for JSDoc, eslint still complains)
 - Data and state of tweenables are not typeable as template types are not supported well enough in TSDoc
 - I've had to modify a *ton* of JSDoc comments and there is a chance I might have broken something and missed it

Those could likely be fixed by either switching the whole codebase to typescript (preferably not as the transpiling process might have unwanted side effects on performance) or creating the types manually and manually update them on any changes to the public API (makes maintenance just a bit more painful). Do you think one of those would be a better option?

Closes #68 