### PR TITLE
Add support for RGBA color values

### DIFF
--- a/src/token.js
+++ b/src/token.js
@@ -1,13 +1,16 @@
 const R_NUMBER_COMPONENT = /(\d|-|\.)/
 const R_FORMAT_CHUNKS = /([^\-0-9.]+)/g
 const R_UNFORMATTED_VALUES = /[0-9.-]+/g
-const R_RGB = (() => {
+const R_RGBA = (() => {
   const number = R_UNFORMATTED_VALUES.source
   const comma = /,\s*/.source
 
-  return new RegExp(`rgb\\(${number}${comma}${number}${comma}${number}\\)`, 'g')
+  return new RegExp(
+    `rgba?\\(${number}${comma}${number}${comma}${number}(${comma}${number})?\\)`,
+    'g'
+  )
 })()
-const R_RGB_PREFIX = /^.*\(/
+const R_RGBA_PREFIX = /^.*\(/
 const R_HEX = /#([0-9]|[a-f]){3,6}/gi
 const VALUE_PLACEHOLDER = 'VAL'
 
@@ -162,11 +165,16 @@ const sanitizeObjectForHexProps = stateObject => {
  * @return {string}
  * @private
  */
-const sanitizeRGBChunk = rgbChunk => {
-  const numbers = rgbChunk.match(R_UNFORMATTED_VALUES).map(Math.floor)
-  const prefix = rgbChunk.match(R_RGB_PREFIX)[0]
+const sanitizeRGBAChunk = rgbChunk => {
+  const rgbaRawValues = rgbChunk.match(R_UNFORMATTED_VALUES)
+  const rgbNumbers = rgbaRawValues.slice(0, 3).map(Math.floor)
+  const prefix = rgbChunk.match(R_RGBA_PREFIX)[0]
 
-  return `${prefix}${numbers.join(',')})`
+  if (rgbaRawValues.length === 3) {
+    return `${prefix}${rgbNumbers.join(',')})`
+  } else if (rgbaRawValues.length === 4) {
+    return `${prefix}${rgbNumbers.join(',')},${rgbaRawValues[3]})`
+  }
 }
 
 /**
@@ -178,7 +186,7 @@ const sanitizeRGBChunk = rgbChunk => {
  * @private
  */
 const sanitizeRGBChunks = formattedString =>
-  filterStringChunks(R_RGB, formattedString, sanitizeRGBChunk)
+  filterStringChunks(R_RGBA, formattedString, sanitizeRGBAChunk)
 
 /**
  * Note: It's the duty of the caller to convert the Array elements of the

--- a/src/token.js
+++ b/src/token.js
@@ -175,6 +175,8 @@ const sanitizeRGBAChunk = rgbChunk => {
   } else if (rgbaRawValues.length === 4) {
     return `${prefix}${rgbNumbers.join(',')},${rgbaRawValues[3]})`
   }
+
+  throw new Error(`Invalid rgbChunk: ${rgbChunk}`)
 }
 
 /**

--- a/src/token.test.js
+++ b/src/token.test.js
@@ -25,6 +25,19 @@ test('can tween an rgb color with a number in the tween', () => {
   expect(interpolated.color).toEqual(to.color)
 })
 
+test('can tween an rgba color with a number in the tween', () => {
+  const from = { color: 'rgba(0,128,255,0)', x: 0 },
+    to = { color: 'rgba(128,255,0,1)', x: 10 }
+
+  let interpolated = interpolate(from, to, 0)
+  expect(interpolated.color).toEqual(from.color)
+  interpolated = interpolate(from, to, 0.5)
+  expect(interpolated.color).toEqual('rgba(64,191,127,0.5)')
+  expect(interpolated.x).toEqual(5)
+  interpolated = interpolate(from, to, 1)
+  expect(interpolated.color).toEqual(to.color)
+})
+
 test('can tween hex color values', () => {
   const from = { color: '#ff00ff' },
     to = { color: '#00ff00' }
@@ -49,7 +62,7 @@ test('can tween multiple rgb color tokens', () => {
   expect(interpolated.color).toEqual(to.color)
 })
 
-test("each token chunk can have it's own easing curve", () => {
+test('each token chunk can have its own easing curve', () => {
   const from = { color: 'rgb(0,0,0)' },
     to = { color: 'rgb(255,255,255)' },
     easing = 'linear easeInQuad easeInCubic'


### PR DESCRIPTION
This PR addresses #136 by adding support for `rgba` color strings. This was mostly already working before, as the token plugin supports arbitrary strings. However, the mid-tween rendered `rgba` strings would have decimal values as the `r`, `g`, and `b` values. This doesn't seem to be a problem for modern browsers, but it's also not quite correct. It seems safest to stick to the expectation of having `r`, `g`, and `b` be integer values, which is what this PR does.

/cc @hoomanaskari