### PR TITLE
adding support for array custom easing

### DIFF
--- a/src/bezier.js
+++ b/src/bezier.js
@@ -146,9 +146,8 @@ function cubicBezierAtTime(t, p1x, p1y, p2x, p2y, duration) {
  *  @param {number} x2
  *  @param {number} y2
  *  @return {Function}
- *  @private
  */
-export const getCubicBezierTransition = (x1, y1, x2, y2) => pos =>
+export const getCubicBezierTransition = (x1 = 0.250, y1 = 0.250, x2 = 0.750, y2 = 0.750) => pos =>
   cubicBezierAtTime(pos, x1, y1, x2, y2, 1)
 
 /**

--- a/src/bezier.js
+++ b/src/bezier.js
@@ -148,7 +148,7 @@ function cubicBezierAtTime(t, p1x, p1y, p2x, p2y, duration) {
  *  @return {Function}
  *  @private
  */
-const getCubicBezierTransition = (x1, y1, x2, y2) => pos =>
+export const getCubicBezierTransition = (x1, y1, x2, y2) => pos =>
   cubicBezierAtTime(pos, x1, y1, x2, y2, 1)
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -89,7 +89,7 @@ export { setBezierFunction, unsetBezierFunction } from './bezier'
  * custom environments such as `<canvas>`.
  *
  * Legacy property name: `step`.
- * @property {Object<string|shifty.easingFunction>|string|shifty.easingFunction} [easing]
+ * @property {Object<string|shifty.easingFunction>|string|shifty.easingFunction|Array.<number>} [easing]
  * Easing curve name(s) or {@link shifty.easingFunction}(s) to apply
  * to the properties of the tween.  If this is an Object, the keys should
  * correspond to `to`/`from`.  You can learn more about this in the {@tutorial

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -261,7 +261,7 @@ export const scheduleUpdate = () => {
  * If the tween has only one easing across all properties, that function is
  * returned directly.
  * @param {Record<string, string|Function>} fromTweenParams
- * @param {Object|string|Function} [easing]
+ * @param {Object|string|Function|Array.<number>} [easing]
  * @param {Object} [composedEasing] Reused composedEasing object (used internally)
  * @return {Record<string, string|Function>|Function}
  * @private

--- a/src/tweenable.js
+++ b/src/tweenable.js
@@ -1,4 +1,5 @@
 import * as easingFunctions from './easing-functions'
+import { getCubicBezierTransition } from './bezier'
 /** @typedef {import("./index").shifty.filter} shifty.filter */
 /** @typedef {import("./index").shifty.tweenConfig} shifty.tweenConfig */
 /** @typedef {import("./index").shifty.scheduleFunction} shifty.scheduleFunction */
@@ -270,6 +271,12 @@ export const composeEasingObject = (
   easing = DEFAULT_EASING,
   composedEasing = {}
 ) => {
+  if (Array.isArray(easing)) {
+    const cubicBezierTransition = getCubicBezierTransition(...easing)
+
+    return cubicBezierTransition
+  }
+
   let typeofEasing = typeof easing
 
   if (formulas[easing]) {


### PR DESCRIPTION
This PR enables the usage of arrays (bezier curves) to create custom easinging, eliminating the need to generate a named function for the custom easings, which therefore allows the usage of graph/curve editors to customize the easings furthermore. Such arrays must be of length 4 such as the following: `[0.755, 0.05, 0.855, 0.06]`

Further tests might be needed to make sure the import and export of the timeline works seamlessly, the initial tests from my side has worked so far.