### PR TITLE
fix: [fixes #175]  Do not resume complete `Tweenable`s in `Scene`

### DIFF
--- a/src/scene.js
+++ b/src/scene.js
@@ -44,6 +44,16 @@ export class Scene {
   }
 
   /**
+   * A list of {@link Tweenable}s in the scene that have not yet ended (playing
+   * or not).
+   * @member Scene#playingTweenables
+   * @type {Array.<Tweenable>}
+   */
+  get playingTweenables() {
+    return this.#tweenables.filter(tweenable => !tweenable.hasEnded())
+  }
+
+  /**
    * The {@link external:Promise}s for all {@link Tweenable}s in this
    * {@link Scene} that have been configured with {@link
    * Tweenable#setConfig}. Note that each call of {@link
@@ -146,7 +156,7 @@ export class Scene {
    * @return {Scene}
    */
   resume() {
-    this.#tweenables.forEach(tweenable => tweenable.resume())
+    this.playingTweenables.forEach(tweenable => tweenable.resume())
 
     return this
   }

--- a/src/scene.test.js
+++ b/src/scene.test.js
@@ -109,12 +109,31 @@ describe('resume', () => {
     scene = new Scene(new Tweenable(), new Tweenable())
   })
 
-  test('resumes all Tweenables', () => {
+  test('resumes Tweenables', () => {
     scene.play()
     scene.pause()
     scene.resume()
 
     expect(scene.isPlaying()).toBeTruthy()
+  })
+
+  test('does not resume Tweenables that have ended', () => {
+    const tweenable1 = new Tweenable()
+    const tweenable2 = new Tweenable()
+
+    scene = new Scene(tweenable1, tweenable2)
+
+    jest.spyOn(tweenable1, 'hasEnded').mockReturnValue(false)
+    jest.spyOn(tweenable1, 'resume')
+    jest.spyOn(tweenable2, 'hasEnded').mockReturnValue(true)
+    jest.spyOn(tweenable2, 'resume')
+
+    scene.play()
+    scene.pause()
+    scene.resume()
+
+    expect(tweenable1.resume).toHaveBeenCalled()
+    expect(tweenable2.resume).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
This PR addresses #175 by preventing completed `Tweenable`s from being `resume()`ed by `Scene#resume`.