### PR TITLE
fix(#189): Define `unpkg` export

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "url": "https://github.com/jeremyckahn/shifty.git"
   },
   "description": "The fastest JavaScript animation engine on the web",
-  "browser": "dist/shifty.js",
-  "main": "dist/shifty.node.js",
+  "browser": "./dist/shifty.js",
+  "main": "./dist/shifty.node.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    "unpkg": "./dist/shifty.js"
+  },
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@babel/plugin-proposal-class-properties": "^7.18.6",


### PR DESCRIPTION
This PR is a speculative fix for #189. It will need to be released to NPM to see if it fixes the issue.